### PR TITLE
NotFoundコンポーネントの単体テスト追加と next-router-mock の導入

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "husky": "^8.0.3",
         "jsdom": "^24.0.0",
         "lint-staged": "^15.2.2",
+        "next-router-mock": "^0.9.13",
         "postcss": "^8",
         "prettier": "^3.2.5",
         "prisma": "^5.14.0",
@@ -16987,6 +16988,16 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/next-router-mock": {
+      "version": "0.9.13",
+      "resolved": "https://registry.npmjs.org/next-router-mock/-/next-router-mock-0.9.13.tgz",
+      "integrity": "sha512-906n2RRaE6Y28PfYJbaz5XZeJ6Tw8Xz1S6E31GGwZ0sXB6/XjldD1/2azn1ZmBmRk5PQRkzjg+n+RHZe5xQzWA==",
+      "dev": true,
+      "peerDependencies": {
+        "next": ">=10.0.0",
+        "react": ">=17.0.0"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "husky": "^8.0.3",
     "jsdom": "^24.0.0",
     "lint-staged": "^15.2.2",
+    "next-router-mock": "^0.9.13",
     "postcss": "^8",
     "prettier": "^3.2.5",
     "prisma": "^5.14.0",

--- a/src/app/not-found.test.tsx
+++ b/src/app/not-found.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import NotFound from './not-found'
+import mockRouter from 'next-router-mock'
+import { MemoryRouterProvider } from 'next-router-mock/MemoryRouterProvider'
+import userEvent from '@testing-library/user-event'
+
+describe('Not Found Component', () => {
+  test('renders correctly', () => {
+    render(<NotFound />)
+
+    const heading = screen.getByRole('heading', { level: 1 })
+
+    expect(heading).toHaveTextContent('404')
+  })
+
+  test('redirects to home page when "ホームに戻る" button is clicked', async () => {
+    const user = userEvent.setup()
+
+    render(<NotFound />, { wrapper: MemoryRouterProvider })
+
+    const button = screen.getByRole('button', { name: 'ホームに戻る' })
+
+    await user.click(button)
+    expect(mockRouter.asPath).toEqual('/')
+  })
+})


### PR DESCRIPTION
## 実装関連リンク

## 概要
1. `next-router-mock` パッケージを `devDependencies` に追加。これにより、Next.js のルーティングをモックするための機能を提供。
2. `NotFound` コンポーネントの単体テストを追加
